### PR TITLE
Allow get_base_purposes to return null or an array

### DIFF
--- a/classes/base_purpose.php
+++ b/classes/base_purpose.php
@@ -52,7 +52,7 @@ class base_purpose {
         return preg_replace('/^aipurpose_(.*)\\\\.*/', '$1', get_class($this));
     }
 
-    public final function get_available_purpose_options(): array {
+    public final function get_available_purpose_options(): ?array {
         $options = [];
         $options['component'] = PARAM_TEXT;
         $options['contextid'] = PARAM_INT;


### PR DESCRIPTION
When no purposes were enabled (or available?) I was seeing the error
Exception - local_ai_manager\base_purpose::get_all_purposes(): Return value must be of type array, null returned