### PR TITLE
Typo instancedisabled instead of instanceenabled.

### DIFF
--- a/templates/instancetable.mustache
+++ b/templates/instancetable.mustache
@@ -95,7 +95,7 @@
                         {{/purposesroleextended}}
                     </td>
                     <td>
-                        {{#enabled}}<span class="text-success"><i class="fa fa-check" title="{{#str}}instancedisabled, local_ai_manager{{/str}}"></i></span>{{/enabled}}
+                        {{#enabled}}<span class="text-success"><i class="fa fa-check" title="{{#str}}instanceenabled, local_ai_manager{{/str}}"></i></span>{{/enabled}}
                         {{^enabled}}<span class="text-danger"><i class="fa fa-ban" title="{{#str}}instancedisabled, local_ai_manager{{/str}}"></i></span>{{/enabled}}</td>
                 </tr>
             {{/instances}}


### PR DESCRIPTION
That looked weird.

Sure it's not a typo?

<img width="1242" height="682" alt="image" src="https://github.com/user-attachments/assets/7e74a2e7-2852-42bf-9db3-556b56794e63" />

Excuse my german …